### PR TITLE
Temporary replaces API endpoint with mirror

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,8 @@
 
 			function stats(first = false) {
 				Promise.resolve($.ajax({
-					url: "https://api.sugarchain.org/info",
+					// url: "https://api.sugarchain.org/info",
+					url: "https://api.sugar.wtf/info",
 				})).then(function(data) {
 					$("#height .current").attr("href", "https://1explorer.sugarchain.org/block/" + data["result"]["bestblockhash"])
 					$("#height .current").text(data["result"]["blocks"])

--- a/index.html
+++ b/index.html
@@ -201,7 +201,8 @@
 					// url: "https://api.sugarchain.org/info",
 					url: "https://api.sugar.wtf/info",
 				})).then(function(data) {
-					$("#height .current").attr("href", "https://1explorer.sugarchain.org/block/" + data["result"]["bestblockhash"])
+					// $("#height .current").attr("href", "https://1explorer.sugarchain.org/block/" + data["result"]["bestblockhash"])
+					$("#height .current").attr("href", "https://sugar.wtf/#/block/" + data["result"]["bestblockhash"])
 					$("#height .current").text(data["result"]["blocks"])
 					if (first) {
 						height_start = data["result"]["blocks"]


### PR DESCRIPTION
Due to sugarchain.org outage I've temporarely replaced api and explorer domains to sugar.wtf